### PR TITLE
data_prep: Fix bug for jvm argument handling (#515)

### DIFF
--- a/data_prep/introspector.py
+++ b/data_prep/introspector.py
@@ -545,17 +545,23 @@ def get_function_signature(function: dict, project: str) -> str:
 
 
 # TODO(dongge): Remove this function when FI fixes it.
-def _parse_type_from_raw_tagged_type(tagged_type: str) -> str:
+def _parse_type_from_raw_tagged_type(tagged_type: str, language: str) -> str:
   """Returns type name from |tagged_type| such as struct.TypeA"""
   # Assume: Types do not contain dot(.).
+  # (ascchan): This assumption is wrong on Java projects because
+  # most full qulified classes name of Java projects have dot(.) to
+  # identify the package name of the classes. Thus for Java projects,
+  # this action needed to be skipped until this function is removed.
+  if language == 'jvm':
+    return tagged_type
   return tagged_type.split('.')[-1]
 
 
-def _group_function_params(param_types: list[str],
-                           param_names: list[str]) -> list[dict[str, str]]:
+def _group_function_params(param_types: list[str], param_names: list[str],
+                           language: str) -> list[dict[str, str]]:
   """Groups the type and name of each parameter."""
   return [{
-      'type': _parse_type_from_raw_tagged_type(param_type),
+      'type': _parse_type_from_raw_tagged_type(param_type, language),
       'name': param_name
   } for param_type, param_name in zip(param_types, param_names)]
 
@@ -723,7 +729,7 @@ def populate_benchmarks_using_introspector(project: str, language: str,
             return_type=_get_clean_return_type(function, project),
             params=_group_function_params(
                 _get_clean_arg_types(function, project),
-                _get_arg_names(function, project, language)),
+                _get_arg_names(function, project, language), language),
             exceptions=_get_exceptions(function),
             is_jvm_static=_is_jvm_static(function),
             target_path=harness,


### PR DESCRIPTION
It is found that there is a temporary function in
data_prep/introspector.py for fixing a wrong function name with struct for c projects. But this function accidentally affected Java projects because the function assumed that all function names wouldn't have a dot(.) character. This assumption is wrong for Java projects since most of the Java classes will have a dot(.) character in the fully qualified class name to identify its package. This PR fixes the problem by skipping the process if it is a Java project. This could be removed if the temporary function is removed in later PRs.

---------